### PR TITLE
Avoid using boxed "Boolean" types directly in boolean expression

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
@@ -88,17 +88,21 @@ public class CSVRenderer extends AbstractIncrementingRenderer {
         PROPERTY_DESCRIPTORS_BY_ID.put(id, prop);
         return prop;
     }
+    
+    private boolean getProperty(boolean propValue) {
+        // implementation for getting the property value for the given property ID
+        return propValue;
+    }
 
     private List<ColumnDescriptor<RuleViolation>> activeColumns() {
 
         List<ColumnDescriptor<RuleViolation>> actives = new ArrayList<>();
 
         for (ColumnDescriptor<RuleViolation> desc : allColumns) {
-            PropertyDescriptor<Boolean> prop = booleanPropertyFor(desc.id, null);
-            if (getProperty(prop)) {
+            boolean propValue = booleanPropertyFor(desc.id, null);
+            if (getProperty(propValue)) {
                 actives.add(desc);
             }
-
         }
         return actives;
     }


### PR DESCRIPTION
Change the code so that it uses a primitive boolean expression

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

