### PR TITLE
Make severity a static final constant or non-public.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateIssue.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateIssue.java
@@ -15,11 +15,18 @@ public class CodeClimateIssue {
     public Content content;
     public String[] categories;
     public Location location;
-    public String severity;
+    private String severity;
     public int remediation_points; // SUPPRESS CHECKSTYLE underscore is required per codeclimate format
 
     public CodeClimateIssue() {
         type = "issue"; // the default type for PMD violations when reporting as code climate
+    }
+    public String getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(String severity) {
+        this.severity = severity;
     }
 
     /**


### PR DESCRIPTION
Class variable fields should not have public accessibility

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

